### PR TITLE
Add additional scripts for copying and duplicating metacards

### DIFF
--- a/copy_metacards.sh
+++ b/copy_metacards.sh
@@ -2,16 +2,18 @@
 
 METACARD_DIR=~/Downloads/xml
 CDM_DIR=/tmp/cdm
+DEFAULT_NUM_COPIES=25
+NUM_COPIES=${1-$DEFAULT_NUM_COPIES}
+NUM_FILES_IN_METACARD_DIR=$( count_files_in_dir $METACARD_DIR )
 
 count_files_in_dir () {
     return $( ls -l $1 | wc -l )
 }
 
 main () {
-    NUM_FILES_IN_METACARD_DIR=$( count_files_in_dir $METACARD_DIR )
     START_TIME=$SECONDS
 
-    for i in `seq 1 25`;
+    for i in `seq 1 $NUM_TIMES_TO_COPY`;
     do
         # counts the # of lines in the ls output for the CDM directory
         NUM_FILES_IN_CDM_DIR=$( count_files_in_dir $CDM_DIR )
@@ -30,7 +32,7 @@ main () {
 
     END_TIME=$SECONDS
 
-    echo "Finished copying $(( 5 * 25 )) files in $(( END_TIME - START_TIME  )) seconds."
+    echo "Finished copying $(( 5 * NUM_TIMES_TO_COPY )) files in $(( END_TIME - START_TIME  )) seconds."
 }
 
 main

--- a/copy_metacards.sh
+++ b/copy_metacards.sh
@@ -3,26 +3,35 @@
 METACARD_DIR=~/Downloads/xml
 CDM_DIR=/tmp/cdm
 
-START_TIME=$SECONDS
+count_files_in_dir () {
+    return $( ls -l $1 | wc -l )
+}
 
-for i in `seq 1 25`;
-do
-    # counts the # of lines in the ls output for the CDM directory
-    NUM_FILES_IN_CDM_DIR=$( ls -l $CDM_DIR | wc -l )
-    # sleep for 1 seconds and check for empty directory
-    while [ $NUM_FILES_IN_CDM_DIR -gt 0 ]
+main () {
+    NUM_FILES_IN_METACARD_DIR=$( count_files_in_dir $METACARD_DIR )
+    START_TIME=$SECONDS
+
+    for i in `seq 1 25`;
     do
-        sleep 1
-        NUM_FILES_IN_CDM_DIR=$( ls -l $CDM_DIR | wc -l )
+        # counts the # of lines in the ls output for the CDM directory
+        NUM_FILES_IN_CDM_DIR=$( count_files_in_dir $CDM_DIR )
+        # sleep for 1 seconds and check for empty directory
+        while [ $NUM_FILES_IN_CDM_DIR -gt 0 ]
+        do
+            sleep 1
+            NUM_FILES_IN_CDM_DIR=$( count_files_in_dir $CDM_DIR )
+        done
+
+        # copies the XML files and sleeps for 5 seconds to wait for the metacards to be ingested and moved
+        cp ${METACARD_DIR}/*.xml $CDM_DIR
+        echo "Copied ${NUM_FILES_IN_METACARD_DIR} XML files to ${CDM_DIR}"
+        sleep 5
     done
 
-    # copies the XML files and sleeps for 5 seconds to wait for the metacards to be ingested and moved
-    cp ${METACARD_DIR}/*.xml $CDM_DIR
-    echo "Copied 5 XML files to ${CDM_DIR}"
-    sleep 5
-done
+    END_TIME=$SECONDS
 
-END_TIME=$SECONDS
+    echo "Finished copying $(( 5 * 25 )) files in $(( END_TIME - START_TIME  )) seconds."
+}
 
-echo "Finished copying $(( 5 * 25 )) files in $(( END_TIME - START_TIME  )) seconds."
-
+main
+exit 0

--- a/copy_metacards.sh
+++ b/copy_metacards.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
-METACARD_DIRECTORY=~/Downloads/xml
-CDM_DIRECTORY=/tmp/cdm
+METACARD_DIR=~/Downloads/xml
+CDM_DIR=/tmp/cdm
 
 START_TIME=$SECONDS
 
 for i in `seq 1 25`;
 do
-    cp ${METACARD_DIRECTORY}/*.xml $CDM_DIRECTORY
-    echo "Copied 5 XML files to ${CDM_DIRECTORY}"
+    # counts the # of lines in the ls output for the CDM directory
+    NUM_FILES_IN_CDM_DIR=$(( ls -l CDM_DIR | wc -l ))
+    # sleep for 1 seconds and check for empty directory
+    while [ $NUM_FILES_IN_CDM_DIR -gt 0 ]
+    do
+        sleep 1
+        NUM_FILES_IN_CDM_DIR=$(( ls -l CDM_DIR | wc -l ))
+    done
+
+    # copies the XML files and sleeps for 5 seconds to wait for the metacards to be ingested and moved
+    cp ${METACARD_DIR}/*.xml $CDM_DIR
+    echo "Copied 5 XML files to ${CDM_DIR}"
     sleep 5
 done
 
 END_TIME=$SECONDS
 
-echo "\nFinished copying $(( 5 * 25 )) files in $(( END_TIME - START_TIME  )) seconds."
+echo "Finished copying $(( 5 * 25 )) files in $(( END_TIME - START_TIME  )) seconds."
 

--- a/copy_metacards.sh
+++ b/copy_metacards.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+METACARD_DIRECTORY=~/Downloads/xml
+CDM_DIRECTORY=/tmp/cdm
+
+START_TIME=$SECONDS
+
+for i in `seq 1 25`;
+do
+    cp ${METACARD_DIRECTORY}/*.xml $CDM_DIRECTORY
+    echo "Copied 5 XML files to ${CDM_DIRECTORY}"
+    sleep 5
+done
+
+END_TIME=$SECONDS
+
+echo "\nFinished copying $(( 5 * 25 )) files in $(( END_TIME - START_TIME  )) seconds."
+

--- a/copy_metacards.sh
+++ b/copy_metacards.sh
@@ -8,12 +8,12 @@ START_TIME=$SECONDS
 for i in `seq 1 25`;
 do
     # counts the # of lines in the ls output for the CDM directory
-    NUM_FILES_IN_CDM_DIR=$(( ls -l CDM_DIR | wc -l ))
+    NUM_FILES_IN_CDM_DIR=$( ls -l $CDM_DIR | wc -l )
     # sleep for 1 seconds and check for empty directory
     while [ $NUM_FILES_IN_CDM_DIR -gt 0 ]
     do
         sleep 1
-        NUM_FILES_IN_CDM_DIR=$(( ls -l CDM_DIR | wc -l ))
+        NUM_FILES_IN_CDM_DIR=$( ls -l $CDM_DIR | wc -l )
     done
 
     # copies the XML files and sleeps for 5 seconds to wait for the metacards to be ingested and moved

--- a/duplicate_metacard_creator.sh
+++ b/duplicate_metacard_creator.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DEFAULT_NUM=5
+# use default number if no command line argument given
+NUM_OF_METACARDS=${1-$DEFAULT_NUM}
+CDM_DIR_PATH=/tmp/cdm
+FILENAME="dup_metacard_test"
+
+echo "Number of files to duplicate: ${NUM_OF_METACARDS}"
+sleep 1
+echo
+
+START_TIME=$SECONDS
+
+for i in `seq 1 $NUM_OF_METACARDS`;
+do
+    DUP_TEXT=$( cat /dev/urandom| LC_CTYPE=C tr -dc 'a-f0-9' | fold -w 20 | head -n 1  )
+
+    for j in `seq 1 2`;
+    do
+        DUP_FILENAME="${CDM_DIR_PATH}/${FILENAME}_${i}_${j}.txt"
+        echo "Duplicate text: ${DUP_TEXT}"
+        echo $DUP_TEXT >> $DUP_FILENAME
+        echo "Created file \"$DUP_FILENAME\""
+    done
+done
+
+END_TIME=$SECONDS
+echo "Created ${NUM_OF_METACARDS} duplicate files in $(( END_TIME - START_TIME )) seconds."
+


### PR DESCRIPTION
# Changes

- Added script for creating duplicate metacards
  - Different filenames with same text content
- Added script for copying over existing XML metacards
  - Moves files from specified directory to CDM directory and waits for ingest